### PR TITLE
fix tests

### DIFF
--- a/lib/src/lints/bool_comparison.rs
+++ b/lib/src/lints/bool_comparison.rs
@@ -17,13 +17,13 @@ use rnix::{
 /// ## Example
 /// Instead of checking the value of `x`:
 ///
-/// ```
+/// ```nix
 /// if x == true then 0 else 1
 /// ```
 ///
 /// Use `x` directly:
 ///
-/// ```
+/// ```nix
 /// if x then 0 else 1
 /// ```
 #[lint(

--- a/lib/src/lints/collapsible_let_in.rs
+++ b/lib/src/lints/collapsible_let_in.rs
@@ -17,7 +17,7 @@ use rowan::Direction;
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// let
 ///   a = 2;
 /// in
@@ -29,7 +29,7 @@ use rowan::Direction;
 ///
 /// Merge both `let-in` expressions:
 ///
-/// ```
+/// ```nix
 /// let
 ///   a = 2;
 ///   b = 3;

--- a/lib/src/lints/empty_let_in.rs
+++ b/lib/src/lints/empty_let_in.rs
@@ -16,13 +16,13 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// let in pkgs.statix
 /// ```
 ///
 /// Preserve only the body of the `let-in` expression:
 ///
-/// ```
+/// ```nix
 /// pkgs.statix
 /// ```
 #[lint(

--- a/lib/src/lints/empty_pattern.rs
+++ b/lib/src/lints/empty_pattern.rs
@@ -18,7 +18,7 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// client = { ... }: {
 ///   imports = [ self.nixosModules.irmaseal-pkg ];
 ///   services.irmaseal-pkg.enable = true;
@@ -28,7 +28,7 @@ use rnix::{
 /// Replace the empty variadic pattern with `_` to indicate that you
 /// intend to ignore the argument:
 ///
-/// ```
+/// ```nix
 /// client = _: {
 ///   imports = [ self.nixosModules.irmaseal-pkg ];
 ///   services.irmaseal-pkg.enable = true;

--- a/lib/src/lints/eta_reduction.rs
+++ b/lib/src/lints/eta_reduction.rs
@@ -17,7 +17,7 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// let
 ///   double = i: 2 * i;
 /// in
@@ -27,7 +27,7 @@ use rnix::{
 /// The lambda passed to the `map` function is eta-reducible, and the
 /// result reads more naturally:
 ///
-/// ```
+/// ```nix
 /// let
 ///   double = i: 2 * i;
 /// in

--- a/lib/src/lints/legacy_let_syntax.rs
+++ b/lib/src/lints/legacy_let_syntax.rs
@@ -17,7 +17,7 @@ use rnix::{
 ///
 /// Legacy let syntax makes use of an attribute set annotated with
 /// `let` and expects a `body` attribute.
-/// ```
+/// ```nix
 /// let {
 ///   body = x + y;
 ///   x = 2;
@@ -28,7 +28,7 @@ use rnix::{
 /// This is trivially representible via `rec`, which is documented
 /// and more widely known:
 ///
-/// ```
+/// ```nix
 /// rec {
 ///   body = x + y;
 ///   x = 2;

--- a/lib/src/lints/manual_inherit.rs
+++ b/lib/src/lints/manual_inherit.rs
@@ -16,7 +16,7 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// let
 ///   a = 2;
 /// in
@@ -25,7 +25,7 @@ use rnix::{
 ///
 /// Try `inherit` instead:
 ///
-/// ```
+/// ```nix
 /// let
 ///   a = 2;
 /// in

--- a/lib/src/lints/manual_inherit_from.rs
+++ b/lib/src/lints/manual_inherit_from.rs
@@ -16,7 +16,7 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// let
 ///   mtl = pkgs.haskellPackages.mtl;
 /// in
@@ -25,7 +25,7 @@ use rnix::{
 ///
 /// Try `inherit` instead:
 ///
-/// ```
+/// ```nix
 /// let
 ///   inherit (pkgs.haskellPackages) mtl;
 /// in

--- a/lib/src/lints/redundant_pattern_bind.rs
+++ b/lib/src/lints/redundant_pattern_bind.rs
@@ -17,13 +17,13 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// inputs @ { ... }: inputs.nixpkgs
 /// ```
 ///
 /// Remove the pattern altogether:
 ///
-/// ```
+/// ```nix
 /// inputs: inputs.nixpkgs
 /// ```
 #[lint(

--- a/lib/src/lints/unquoted_splice.rs
+++ b/lib/src/lints/unquoted_splice.rs
@@ -16,7 +16,7 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// let
 ///   pkgs = nixpkgs.legacyPackages.${system};
 /// in
@@ -25,7 +25,7 @@ use rnix::{
 ///
 /// Quote the splice expression:
 ///
-/// ```
+/// ```nix
 /// let
 ///   pkgs = nixpkgs.legacyPackages."${system}";
 /// in

--- a/lib/src/lints/useless_parens.rs
+++ b/lib/src/lints/useless_parens.rs
@@ -15,7 +15,7 @@ use rnix::{
 ///
 /// ## Example
 ///
-/// ```
+/// ```nix
 /// let
 ///   double = (x: 2 * x);
 ///   ls = map (double) [ 1 2 3 ];
@@ -25,7 +25,7 @@ use rnix::{
 ///
 /// Remove unnecessary parentheses:
 ///
-/// ```
+/// ```nix
 /// let
 ///   double = x: 2 * x;
 ///   ls = map double [ 1 2 3 ];


### PR DESCRIPTION
rustdoc defaults code blocks to rust and tries compile them as doc-tests, resulting in failures in tests

fixes #11