### PR TITLE
Add aarch64-linux as supported system in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     let
       inherit (gitignore.lib) gitignoreSource;
 
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       nixpkgsFor = forAllSystems (system:
         import nixpkgs {


### PR DESCRIPTION
Builds and runs perfectly fine on `aarch64-linux`.

Solves https://github.com/nerdypepper/statix/issues/25.