### PR TITLE
docs: add homebrew installation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ fix` can fix several such occurrences.
 
 For the time-being, `statix` works only with ASTs
 produced by the `rnix-parser` crate and does not evaluate
-any nix code (imports, attr sets etc.). 
+any nix code (imports, attr sets etc.).
 
 ## Examples
 
@@ -46,6 +46,12 @@ nix run git+https://git.peppe.rs/languages/statix -- --help
 
 # save time on builds using cachix
 cachix use statix
+```
+
+Install with [brew/linuxbrew](https://brew.sh)
+
+```bash
+brew install statix
 ```
 
 ## Usage


### PR DESCRIPTION
closes #24
relates to Homebrew/homebrew-core#91030

---

```
$ brew install statix
==> Downloading https://ghcr.io/v2/homebrew/core/statix/manifest
...
==> Pouring statix--0.4.2.arm64_monterey.bottle.tar.gz
🍺  /opt/homebrew/Cellar/statix/0.4.2: 8 files, 2.9MB
```