### PR TITLE
create release v0.5.3 for return code fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "statix"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ariadne",
  "clap",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statix"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2018"
 license = "MIT"
 authors = [ "Akshay <nerdy@peppe.rs>" ]


### PR DESCRIPTION
The currently released statix version 0.5.2 is always returning exit code 1. Somehow this slipped through my testing in https://github.com/nerdypepper/statix/pull/34.

This bug was already fixed in https://github.com/nerdypepper/statix/commit/014be14e7dc64520b41aedb2d9c9aa719cdf0577 so lets release it so people can use it.