### PR TITLE
use `self` for `src`.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
             inherit pname;
             inherit (packageMeta) version;
 
-            src = gitignoreSource ./.;
+            src = self;
             cargoLock.lockFile = ./Cargo.lock;
 
             buildFeatures = "json";


### PR DESCRIPTION
`gitignoreSource` is not needed in flakes and will now work anymore in nix 2.10
flakes.

Closes #44
