### PR TITLE
Add a repeated keys lint

### DIFF
--- a/bin/tests/data/repeated_keys.nix
+++ b/bin/tests/data/repeated_keys.nix
@@ -1,0 +1,15 @@
+[
+  # fine
+  {
+    foo.bar = 1;
+  }
+
+  # too many with same prefix
+  {
+    foo.baz.bar1 = 1;
+    foo.baz.bar2 = 2;
+    foo.baz.bar3 = 3;
+    foo.baz.bar4 = 4;
+    foo.baz.bar5 = 5;
+  }
+]

--- a/bin/tests/main.rs
+++ b/bin/tests/main.rs
@@ -65,5 +65,6 @@ test_lint! {
     faster_zipattrswith => session_info!("2.6"),
     deprecated_to_path => session_info!("2.4"),
     bool_simplification,
-    useless_has_attr
+    useless_has_attr,
+    repeated_keys
 }

--- a/bin/tests/snapshots/main__repeated_keys.snap
+++ b/bin/tests/snapshots/main__repeated_keys.snap
@@ -1,0 +1,13 @@
+---
+source: bin/tests/main.rs
+expression: "&out"
+---
+[W20] Warning: Common key paths should not be repeated
+    ╭─[data/repeated_keys.nix:8:3]
+    │
+  8 │ ╭─▶   {
+ 14 │ ├─▶   }
+    · │         
+    · ╰───────── Key foo used 3 or more times. Can be replaced with foo { foo=...; bar=...; }
+────╯
+

--- a/lib/src/lints.rs
+++ b/lib/src/lints.rs
@@ -20,4 +20,5 @@ lints! {
     deprecated_to_path,
     bool_simplification,
     useless_has_attr,
+    repeated_keys,
 }

--- a/lib/src/lints/repeated_keys.rs
+++ b/lib/src/lints/repeated_keys.rs
@@ -1,0 +1,80 @@
+use crate::{session::SessionInfo, Metadata, Report, Rule};
+
+use std::collections::BTreeMap;
+use if_chain::if_chain;
+use macros::lint;
+use rnix::{
+    types::{AttrSet, KeyValue, TypedNode},
+    NodeOrToken, SyntaxElement, SyntaxKind
+};
+
+/// ## What it does
+/// Prevent repeating keys.
+///
+/// ## Why is this bad?
+/// It's bad for readability and introduces repetition.
+///
+/// ## Example
+/// ```nix
+/// {
+///   foo.key1 = 1;
+///   foo.key2 = 2;
+///   foo.key3 = 3;
+/// }
+/// ```
+///
+/// Don't repeat.
+/// ```nix
+/// {
+///   foo {
+///     key1 = 1;
+///     key2 = 2;
+///     key3 = 3;
+///   }
+/// }
+/// ```
+
+#[lint(
+    name = "repeated_keys",
+    note = "Common key paths should not be repeated",
+    code = 20,
+    match_with = SyntaxKind::NODE_ATTR_SET
+)]
+struct RepeatedKeys;
+
+fn path_counts(attr_set: &AttrSet) -> Vec<String> {
+    let mut counts = BTreeMap::new();
+    counts = attr_set.node().children().filter_map(|ref c| {
+        KeyValue::cast(c.clone()).map(|kv| kv.key().unwrap().path().next().unwrap().to_string())
+    }).fold(counts, |mut acc, x| {
+        *acc.entry(x).or_insert(0) += 1;
+        acc
+    });
+    counts.retain(|_, &mut v| v >= 3);
+    counts.into_keys().collect()
+}
+
+impl Rule for RepeatedKeys {
+    fn validate(&self, node: &SyntaxElement, _sess: &SessionInfo) -> Option<Report> {
+        if_chain! {
+            if let NodeOrToken::Node(node) = node;
+            if let Some(attr_set) = AttrSet::cast(node.clone());
+            then {
+                let repeated = path_counts(&attr_set);
+                if repeated.len() > 0 {
+                    let at = node.text_range();
+                    let mut report = self.report();
+                    for attr in repeated {
+                        let message = format!("Key `{}` used 3 or more times. Can be replaced with `{} {{ foo=...; bar=...; }}`", attr, attr);
+                        report = report.diagnostic(at, message);
+                    }
+                    Some(report)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/lib/src/lints/repeated_keys.rs
+++ b/lib/src/lints/repeated_keys.rs
@@ -45,7 +45,16 @@ struct RepeatedKeys;
 fn path_counts(attr_set: &AttrSet) -> Vec<String> {
     let mut counts = BTreeMap::new();
     counts = attr_set.node().children().filter_map(|ref c| {
-        KeyValue::cast(c.clone()).map(|kv| kv.key().unwrap().path().next().unwrap().to_string())
+        KeyValue::cast(c.clone()).and_then(|kv| {
+            let key = kv.key().unwrap();
+            let mut path = key.path();
+            let first_path_part = path.next().unwrap().to_string();
+            if path.next().is_none() {
+                None
+            } else {
+                Some(first_path_part)
+            }
+        })
     }).fold(counts, |mut acc, x| {
         *acc.entry(x).or_insert(0) += 1;
         acc


### PR DESCRIPTION
Check for repeated keys in attrsets. For example:

```
foo.bar1 = 1;
foo.bar2 = 2;
foo.bar3 = 3;
```

should recommend creating a

```
foo = { ... }
```

The threshold for flagging is 3 repeats.

Since the warning doesn't really belong to a specific key, the location points at the whole AttrSet. It's possible to make it better with a precise suggestion, but it would be a lot of code. Maybe a todo for the future.