### PR TITLE
Warn on a long pattern in top-level lambda

### DIFF
--- a/lib/src/lints.rs
+++ b/lib/src/lints.rs
@@ -20,4 +20,5 @@ lints! {
     deprecated_to_path,
     bool_simplification,
     useless_has_attr,
+    long_root_pattern,
 }

--- a/lib/src/lints/long_root_pattern.rs
+++ b/lib/src/lints/long_root_pattern.rs
@@ -49,6 +49,7 @@ impl Rule for LongRootPattern {
             if let Some(pattern) = lambda.arg();
             if let Some(pattern) = Pattern::cast(pattern.clone());
             if count_pattern_entries(&pattern) > 6;
+            if !pattern.node().text().to_string().contains("\n");
             then {
                 let at = pattern.node().text_range();
                 let message = "Split the long pattern line into multiple lines";

--- a/lib/src/lints/long_root_pattern.rs
+++ b/lib/src/lints/long_root_pattern.rs
@@ -1,4 +1,4 @@
-use crate::{session::SessionInfo, Metadata, Report, Rule};
+use crate::{make, session::SessionInfo, Metadata, Report, Rule, Suggestion};
 
 use if_chain::if_chain;
 use macros::lint;
@@ -53,9 +53,10 @@ impl Rule for LongRootPattern {
             then {
                 let at = pattern.node().text_range();
                 let message = "Split the long pattern line into multiple lines";
+                let replacement = make::multiline_pattern(&pattern).node().clone();
                 Some(
                     self.report()
-                        .diagnostic(at, message),
+                        .suggest(at, message, Suggestion::new(at, replacement)),
                 )
             } else {
                 None

--- a/lib/src/lints/long_root_pattern.rs
+++ b/lib/src/lints/long_root_pattern.rs
@@ -1,0 +1,64 @@
+use crate::{session::SessionInfo, Metadata, Report, Rule};
+
+use if_chain::if_chain;
+use macros::lint;
+use rnix::{
+    types::{Lambda, TypedNode, Pattern},
+    NodeOrToken, SyntaxElement, SyntaxKind
+};
+
+/// ## What it does
+/// Prevent long single-line pattern in root lambda.
+///
+/// ## Why is this bad?
+/// It's bad for readability.
+///
+/// ## Example
+/// ```nix
+/// { lib, and, many, other, names }:
+/// ```
+///
+/// Split into lines.
+/// ```nix
+/// { lib
+/// , and
+/// , many
+/// , other
+/// , names
+/// }:
+/// ```
+
+#[lint(
+    name = "long_root_pattern",
+    note = "Long pattern in the root lambda should be wrapped",
+    code = 21,
+    match_with = SyntaxKind::NODE_ROOT
+)]
+struct LongRootPattern;
+
+fn count_pattern_entries(pattern: &Pattern) -> usize {
+    pattern.entries().count()
+}
+
+impl Rule for LongRootPattern {
+    fn validate(&self, node: &SyntaxElement, _sess: &SessionInfo) -> Option<Report> {
+        if_chain! {
+            if let NodeOrToken::Node(node) = node;
+            if let Some(node) = node.children().next();
+            if let Some(lambda) = Lambda::cast(node.clone());
+            if let Some(pattern) = lambda.arg();
+            if let Some(pattern) = Pattern::cast(pattern.clone());
+            if count_pattern_entries(&pattern) > 6;
+            then {
+                let at = pattern.node().text_range();
+                let message = "Split the long pattern line into multiple lines";
+                Some(
+                    self.report()
+                        .diagnostic(at, message),
+                )
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/lib/src/make.rs
+++ b/lib/src/make.rs
@@ -92,3 +92,10 @@ pub fn binary(lhs: &SyntaxNode, op: &str, rhs: &SyntaxNode) -> types::BinOp {
 pub fn or_default(set: &SyntaxNode, index: &SyntaxNode, default: &SyntaxNode) -> types::OrDefault {
     ast_from_text(&format!("{}.{} or {}", set, index, default))
 }
+
+pub fn multiline_pattern(pattern: &types::Pattern) -> types::Pattern {
+    let wrapped = pattern.entries().map(|ref e| {
+        e.node().text().to_string()
+    }).collect::<Vec<String>>().join("\n, ");
+    ast_from_text(&format!("{{ {}\n}}", wrapped))
+}


### PR DESCRIPTION
When there are more than 6 arguments, suggest splitting into multiple lines.