### PR TITLE
flake: avoid ifd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,26 +21,6 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1635165013,
-        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1645013224,
@@ -60,7 +40,6 @@
     "root": {
       "inputs": {
         "fenix": "fenix",
-        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -8,22 +8,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    gitignore = {
-      url = "github:hercules-ci/gitignore.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
   };
 
   outputs =
     { self
     , nixpkgs
     , fenix
-    , gitignore
     }:
     let
-      inherit (gitignore.lib) gitignoreSource;
-
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       nixpkgsFor = forAllSystems (system:
@@ -32,12 +24,7 @@
           overlays = [ self.overlays.default ];
         });
 
-      chanspec = {
-        date = "2022-02-06";
-        channel = "nightly";
-        sha256 = "oKkTWopCDx4tphzTtRn+zDDtvmIZrL/H44tV2ruSfDw="; # set zeros after modifying channel or date
-      };
-      rustChannel = p: (fenix.overlay p p).fenix.toolchainOf chanspec;
+      rustChannel = p: (fenix.overlay p p).fenix.complete;
 
     in
     {
@@ -59,7 +46,7 @@
             src = self;
             cargoLock.lockFile = ./Cargo.lock;
 
-            buildFeatures = "json";
+            buildFeatures = [ "json" ];
 
             meta = with lib; {
               description = "Lints and suggestions for the Nix programming language";


### PR DESCRIPTION
fixes https://github.com/nerdypepper/statix/issues/52

the ifd was caused by the channel pin, now we are using the latest complete toolchain for fenix. It is still pinned as long as we don't update fenix (with `nix flake update`)

also removed the `gitignore` input since it is unused: https://github.com/nerdypepper/statix/pull/45