### PR TITLE
make eta_reduction less aggressive

### DIFF
--- a/bin/tests/data/eta_reduction.nix
+++ b/bin/tests/data/eta_reduction.nix
@@ -15,4 +15,7 @@ in
 
   # other non-free forms
   (map (f: {inherit f;}.double f.val) [ f ])
+
+  # don't reduce on more complex lambda bodies
+  (map (x: builtins.div 3 x) xs)
 ]

--- a/lib/src/lints/eta_reduction.rs
+++ b/lib/src/lints/eta_reduction.rs
@@ -56,10 +56,13 @@ impl Rule for EtaReduction {
             if let Some(value_node) = body.value();
             if let Some(value) = Ident::cast(value_node);
 
-            if arg.as_str() == value.as_str() ;
+            if arg.as_str() == value.as_str();
 
             if let Some(lambda_node) = body.lambda();
             if !mentions_ident(&arg, &lambda_node);
+	    // lambda body should be no more than a single Ident to
+	    // retain code readability
+	    if let Some(_) = Ident::cast(lambda_node);
 
             then {
                 let at = node.text_range();


### PR DESCRIPTION
Hi! Thank you for this very useful tool.

I found the eta-reduction to be too aggressive for all cases, reducing code readability in complex lambda expressions. When there are more arguments to the call in the lambda body, explicit arguments indicate more useful information to the reader. My idea is to add a restriction that makes it only run for the most primitive expressions. Is that an idea worth pursuing?

The test fixture is a bit contrived. Real-world code can be more complex.